### PR TITLE
add make sound class so threading works

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,7 +10,7 @@ from pydub.generators import Sine
 import threading 
 import time
 
-from make_sounds import play_tone
+from make_sounds import beeper
 
 
 
@@ -110,6 +110,7 @@ clock = pygame.time.Clock()
 
 #stop_event = threading.Event()
 #melody_thread = threading.Thread(target=play_tone, args=(stop_event,))
+beep = beeper()
 
 while running:
     for event in pygame.event.get():
@@ -132,7 +133,7 @@ while running:
                 current_speed = math.sqrt(ball['speed'][0]**2 + ball['speed'][1]**2)
                 balls.append(create_ball(ball['pos'], current_speed, 'left'))
                 ball['last_collision_time'] = current_time
-                threading.Thread(target=play_tone).start() # must be threaded for no lag.  
+                threading.Thread(target=beep.play_sound, args=(['a','b'],)).start()  
                             
                 
         elif ball['pos'][0] + ball['radius'] > 800:

--- a/make_sounds.py
+++ b/make_sounds.py
@@ -5,6 +5,64 @@ import io
 import numpy as np
 import time
 import threading
+
+class beeper:
+    # Noise making class to handle any noises needed during animations.
+
+    def __init__(self):
+        pygame.mixer.init() #initalzie the mixer so threads don't create it. 
+    
+    def sound_generate(self, freq, dur, waveform=None):
+        sample_rate = 44100
+        duration_s = dur / 1000.0
+        t = np.linspace(0, duration_s, int(sample_rate * duration_s), endpoint=False)
+        wave = 2 * (t * freq - np.floor(t * freq + 0.5))
+        wave = (wave * 32767).astype(np.int16)
+
+        audio_segment = AudioSegment(
+        wave.tobytes(),
+        frame_rate=sample_rate,
+        sample_width=wave.dtype.itemsize,
+        channels=1
+        )
+        return audio_segment
+    
+    def play_sound(self, song):
+        melody = AudioSegment.silent(duration=0)
+        for note in song:
+            if note == 'a':
+                print('gunk')
+        
+        a = self.sound_generate(440, 50, waveform='sawtooth')  # 440 Hz for 200 ms
+        b = self.sound_generate(494, 200, waveform='sawtooth')  # 494 Hz for 200 ms
+        c = self.sound_generate(523, 200, waveform='sawtooth')  # 523 Hz for 200 ms
+
+        melody += a
+        melody_buffer = io.BytesIO()
+        melody.export(melody_buffer, format="wav")
+        melody_buffer.seek(0)
+
+        # Load the sound from the BytesIO object
+        sound = pygame.mixer.Sound(melody_buffer.read())
+        sound.play()
+
+    def hhhplay(self, song):
+        melody_buffer = io.BytesIO()
+        song.export(melody_buffer, format="wav")
+        melody_buffer.seek(0)
+        pygame.mixer.music.load(melody_buffer)
+        pygame.mixer.music.play()
+
+        # Keep the script running long enough to hear the sound
+        while pygame.mixer.music.get_busy():
+          pygame.time.Clock().tick(10)
+        pygame.mixer.quit()
+
+
+
+
+
+
 # Function to generate a beep sound
 def generate_beep(frequency, duration_ms, volume=-20.0):
     beep = Sine(frequency).to_audio_segment(duration=duration_ms).apply_gain(volume)
@@ -76,5 +134,3 @@ def play_tone():
 
     # Quit Pygame mixer to free resources
     pygame.mixer.quit()
-
-


### PR DESCRIPTION
the sound file was initializing the pygame mixer every time a thread was created so it blew up. I moved the sound making methods into a class that sets it up before the threads can call it. 